### PR TITLE
Alpine-ize docker image & secure build process.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
-FROM ubuntu
+FROM alpine:3.5
 
 ADD templates/* /templates/
 
 ADD static/ /static/
 
-RUN apt-get update && \
-    apt-get install -y git
-
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.5.4/bin/linux/amd64/kubectl /usr/local/bin/kubectl
-
-RUN chmod +x /usr/local/bin/kubectl
+ADD build.sh /
+RUN /build.sh
 
 COPY kube-applier /kube-applier

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -ex
+KUBECTL_VERSION=1.6.2
+KUBECTL_HASH="9beec3e8a9208da5cac479a164a61bf6a7b0b8716c338f866c4316680f0e9d98"
+
+get_bin()
+{
+  hash="$1"
+  url="$2"
+  outputdir="${3:-/usr/local/bin}"
+  f=$(basename "$url")
+
+  curl -sSL "$url" -o ${outputdir}/"$f"
+  echo "$hash  ${outputdir}/${f}" | sha256sum -c - || exit 10
+  chmod +x ${outputdir}/"$f"
+}
+apk add --update git curl ca-certificates
+
+get_bin $KUBECTL_HASH \
+    "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+
+# Cleanup
+rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*


### PR DESCRIPTION
This saves a bit (hah!) on build size.

```
REPOSITORY                                          TAG                 IMAGE ID            CREATED              SIZE
applier-ubuntu                                      latest              705955d349f3        About a minute ago   358 MB
applier-alpine                                      latest              341824a7c1c0        3 minutes ago        106 MB
```

I took the liberty of also updating `kubectl`.