### PR TITLE
Remove --schema-cache-dir flag

### DIFF
--- a/kube/client.go
+++ b/kube/client.go
@@ -31,9 +31,6 @@ type Client struct {
 	Server string
 	// Location of the written kubeconfig file within the container
 	kubeconfigFilePath string
-
-	// A directory with write permissions for kubectl to load store its schema cache
-	schemaCacheDir string
 }
 
 // Configure writes the kubeconfig file to be used for authenticating kubectl commands.
@@ -44,20 +41,13 @@ func (c *Client) Configure() error {
 	}
 
 	f, err := ioutil.TempFile("", "kubeConfig")
+	c.kubeconfigFilePath = f.Name()
+	log.Printf("Using kubeConfig file:", c.kubeconfigFilePath)
+
 	if err != nil {
 		return fmt.Errorf("Error creating kubeconfig file: %v", err)
 	}
 	defer f.Close()
-
-	c.kubeconfigFilePath = f.Name()
-	log.Printf("Using kubeConfig file:", c.kubeconfigFilePath)
-
-	scd, err := ioutil.TempDir("", "kubectl-schema-cache-dir")
-	if err != nil {
-		log.Printf("Error creating kubectl schema cache dir: %v", err)
-	} else {
-		c.schemaCacheDir = scd
-	}
 
 	token, err := ioutil.ReadFile(tokenPath)
 	if err != nil {
@@ -135,7 +125,7 @@ func isCompatible(clientMajor, clientMinor, serverMajor, serverMinor string) err
 // Apply attempts to "kubectl apply" the file located at path.
 // It returns the full apply command and its output.
 func (c *Client) Apply(path string) (cmd, output string, err error) {
-	args := []string{"kubectl", "apply", "--schema-cache-dir", c.schemaCacheDir, "-f", path}
+	args := []string{"kubectl", "apply", "-f", path}
 	if c.Server != "" {
 		args = append(args, fmt.Sprintf("--kubeconfig=%s", c.kubeconfigFilePath))
 	}


### PR DESCRIPTION
This flag was removed in Kubernetes 1.9 and I don't think we need it
anymore: https://github.com/kubernetes/kubernetes/pull/53232/

Fixes #28 