### PR TITLE
Apply multi-stage build in Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.7
+install: true 
 script:
   - make test-unit
   - .travis/check_workspace.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
+FROM golang:1.7 as builder
+WORKDIR $GOPATH/src/github.com/box/kube-applier
+COPY . $GOPATH/src/github.com/box/kube-applier
+RUN make build
+
 FROM ubuntu
-
+LABEL maintainer="Greg Lyons<glyons@box.com>"
+WORKDIR /root/
 ADD templates/* /templates/
-
 ADD static/ /static/
-
 RUN apt-get update && \
     apt-get install -y git
-
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl /usr/local/bin/kubectl
-
 RUN chmod +x /usr/local/bin/kubectl
-
-COPY kube-applier /kube-applier
+COPY --from=builder /go/src/github.com/box/kube-applier/kube-applier /kube-applier

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-TAG = v0.1.0
+TAG = v0.2.0
 GODEP_BIN = $$GOPATH/bin/godep
 
 deps:
@@ -10,7 +10,7 @@ deps:
 build: clean deps fmt
 	$(ENVVAR) $(GODEP_BIN) go build -o kube-applier
 
-container: build
+container:
 	docker build -t kube-applier:$(TAG) .
 
 clean:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ kube-applier serves a [status page](#status-ui) and provides [metrics](#metrics)
 
 ## Requirements
 * [Go (1.7+)](https://golang.org/dl/)
-* [Docker (1.10+)](https://docs.docker.com/engine/getstarted/step_one/#step-1-get-docker)
+* [Docker (17.05+)](https://docs.docker.com/engine/getstarted/step_one/#step-1-get-docker)
 * [Kubernetes cluster](http://kubernetes.io/docs/getting-started-guides/binary_release/)
     * The kubectl version specified in the Dockerfile must be either the same minor release as the cluster API server, or one release behind the server (e.g. client 1.3 and server 1.4 is fine, but client 1.4 and server 1.3 is not).
     * Supported Kubernetes releases:

--- a/demo/deployment.yaml
+++ b/demo/deployment.yaml
@@ -20,7 +20,7 @@
                 value: "/k8s/resources"
               - name: "LISTEN_PORT"
                 value: "2020"
-            image: "kube-applier:v0.1.0"
+            image: "kube-applier:v0.2.0"
             ports:
               - containerPort: 2020
             volumeMounts:


### PR DESCRIPTION
Multi-stage builds won't require golang environment to build the kube-applier. It will build the go binary inside Docker containers. This needs Docker 17.05 or higher and I updated Docker's version requirement on README.md as well.