### PR TITLE
Dockerfile: Update golang, Add KUBE_VERSION arg, smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM golang:1.7 as builder
+FROM golang:1.12.6 as builder
 WORKDIR $GOPATH/src/github.com/box/kube-applier
 COPY . $GOPATH/src/github.com/box/kube-applier
 RUN make build
 
 FROM ubuntu
+ARG KUBE_VERSION=v1.13.7
 LABEL maintainer="Greg Lyons<glyons@box.com>"
 WORKDIR /root/
+ADD https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+RUN chmod +x /usr/local/bin/kubectl
+RUN apt-get update && \
+    apt-get install -y git && \
+    rm -rf /var/lib/apt/lists/*
 ADD templates/* /templates/
 ADD static/ /static/
-RUN apt-get update && \
-    apt-get install -y git
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl
 COPY --from=builder /go/src/github.com/box/kube-applier/kube-applier /kube-applier


### PR DESCRIPTION
Changes:
- Updated golang to the latest stable (`1.12.6`)
- Added `KUBE_VERSION` build arg with a default of `v1.13.7`. This seemed like a reasonable default since `v1.12.*` is still popular with managed k8s offerings as well as KOPS  and `v1.13.7` is the newest stable version that's compatible with this. 
- Reordered a few build layers for slightly better caching
- Removed apt cache for smaller image size

These changes result in an image that is about 75MB smaller (uncompressed). 

